### PR TITLE
Updating the build.rs file and Cargo.toml package name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
+
 [package]
-name = "liquid-dsp-bindings-sys"
+name = "liquid-dsp-sys"
 version = "0.1.0"
 authors = ["Jacob Holtom <jacob@holtom.me>"]
 edition = "2018"
@@ -8,6 +9,13 @@ license = "WTFPL"
 keywords = ["sdr","dsp","liquid","signal","radio"]
 categories = ["external-ffi-bindings"]
 repository = "https://github.com/jholtom/liquid-dsp-bindings-sys"
+links = "liquid"
+build= "build.rs"
+
+[lib]
+name = "liquid_sys"
+path = "src/lib.rs"
 
 [build-dependencies]
-bindgen = "0.50"
+bindgen = "*"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,6 @@ repository = "https://github.com/jholtom/liquid-dsp-bindings-sys"
 links = "liquid"
 build= "build.rs"
 
-[lib]
-name = "liquid_sys"
-path = "src/lib.rs"
-
 [build-dependencies]
 bindgen = "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 
 [package]
-name = "liquid-dsp-sys"
+name = "liquid-dsp-bindings-sys"
 version = "0.1.0"
 authors = ["Jacob Holtom <jacob@holtom.me>"]
 edition = "2018"

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,61 @@
-extern crate bindgen;
-
 use std::env;
-use std::path::PathBuf;
+use std::env::consts;
+use std::path::Path;
 
-fn main(){
-    println!("cargo:rustc-link-lib=liquid");
-    let bindings = bindgen::Builder::default()
-        .header("wrapper.h")
+use std::fs::File;
+use std::io::Write;
+
+fn format_write(builder: bindgen::Builder, output: &str) {
+    let s = builder
         .generate()
-        .expect("Unable to generate bindings!");
+        .unwrap()
+        .to_string()
+        .replace("/**", "/*")
+        .replace("/*!", "/*");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings.write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+    let mut file = File::create(output).unwrap();
+
+    let _ = file.write(s.as_bytes());
+}
+
+fn common_builder() -> bindgen::Builder {
+    bindgen::builder()
+        .raw_line("#![allow(deprecated)]")
+        .raw_line("#![allow(dead_code)]")
+        .raw_line("#![allow(non_camel_case_types)]")
+        .raw_line("#![allow(non_snake_case)]")
+        .raw_line("#![allow(non_upper_case_globals)]")
+}
+
+fn main() {
+
+    let builder = common_builder()
+        .header("wrapper.h");
+
+    format_write(builder, "src/lib.rs");
+
+    if let Some(lib_dir) = env::var_os("LIQUID_LIB_DIR") {
+
+        let lib_dir = Path::new(&lib_dir);
+        let dylib_name;
+        let target = env::var("TARGET").unwrap();
+
+        if target.contains("windows") {
+            dylib_name = "liquid.lib".to_owned();
+        } else {
+            dylib_name = format!("{}liquid{}", consts::DLL_PREFIX, consts::DLL_SUFFIX);
+        }
+
+        if lib_dir.join(dylib_name).exists() {
+            println!("cargo:rustc-link-search=native={}", lib_dir.display());
+            println!("cargo:rustc-link-lib=liquid");
+            return;
+        }
+
+        println!("cargo:warning=library not found in {}", lib_dir.display());
+        println!("export LIQUID_LIB_DIR with the path to the liquid library, for example ");
+        println!("export LIQUID_LIB_DIR=/usr/lib  ");
+
+        panic!();
+    }
 }


### PR DESCRIPTION
Hi.

- First I changed the package name from  "liquid-dsp-bindings-sys" to name = "liquid-dsp-sys", because I think having the word bindings is kind of redundant.
- Then, I made some enhancements to the build.rs.
build.rs writes the binding generation into a lib.rs file inside of the src/ directory and takes care of the linking process to the native liquid-dsp C library, checking if the platform is either windows or Linux.



