### PR TITLE
Suppressed some warnings, updated rust edition, and updated bindgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 **/*.rs.bk
 Cargo.lock
+
+# Ignore liquid.h and libliquid.a. The user has to build the library themselves. 
+liquid/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["external-ffi-bindings"]
 repository = "https://github.com/jholtom/liquid-dsp-bindings-sys"
 
 [build-dependencies]
-bindgen = "0.68.1"
+bindgen = "0.69.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "These are the low-level C to Rust bindings for liquid-dsp (liquid
 license = "WTFPL"
 keywords = ["sdr","dsp","liquid","signal","radio"]
 categories = ["external-ffi-bindings"]
-repository = "https://github.com/porkiedev/liquid-dsp-bindings-sys"
+repository = "https://github.com/jholtom/liquid-dsp-bindings-sys"
 
 [build-dependencies]
 bindgen = "0.68.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "liquid-dsp-bindings-sys"
 version = "0.1.0"
-authors = ["Jacob Holtom <jacob@holtom.me>"]
-edition = "2018"
+authors = ["Jacob Holtom <jacob@holtom.me>", "Elijah Fry <porkiedev@gmail.com>"]
+edition = "2021"
 description = "These are the low-level C to Rust bindings for liquid-dsp (liquidsdr.org)"
 license = "WTFPL"
 keywords = ["sdr","dsp","liquid","signal","radio"]
 categories = ["external-ffi-bindings"]
-repository = "https://github.com/jholtom/liquid-dsp-bindings-sys"
+repository = "https://github.com/porkiedev/liquid-dsp-bindings-sys"
 
 [build-dependencies]
-bindgen = "0.50"
+bindgen = "0.68.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["external-ffi-bindings"]
 repository = "https://github.com/jholtom/liquid-dsp-bindings-sys"
 
 [build-dependencies]
-bindgen = "0.69.2"
+bindgen = "0.69.4"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# liquid-dsp-bindings-sys
+
+This provides (unsafe) rust bindings to the [liquid-dsp](https://github.com/jgaeddert/liquid-dsp) digital signal processing library.
+
+This was primarily designed to work with Linux, but it *does* work with Windows (albeit it's a little tricky to get working).
+I don't have a Mac so I am unable to verify any functionality whatsoever on MacOS.
+
+Unfortunately, this crate does not build liquid-dsp for you, as that's a whole (platform-specific) challenge in itself.
+## Usage
+This crate can utilize liquid-dsp in 2 ways:
+1. Build and install liquid-dsp into your system normally by following the official [liquid-dsp installation guide](https://liquidsdr.org/doc/installation/).
+2. Build liquid-dsp, clone this repo, create a directory named `liquid`, and copy your compiled `libliquid.a` and `liquid.h` header files into the directory.
+and that should be it! (For Linux users..)
+
+## For Windows users:
+liquid-dsp doesn't *really* have support for windows, because the MSVC compiler doesn't support all of the C99 features that liquid-dsp requires.
+You can get around this by using MingW64 to build liquid-dsp. Unfortunately, the official installation guide with autotools didn't work for me,
+so I ported liquid-dsp to work with CMake. If you're interested, check out my [pull request](https://github.com/jgaeddert/liquid-dsp/pull/353).
+Also, things don't seem to work right if you're using the (default) `stable-x86_64-pc-windows-msvc` rust toolchain.
+I suggest using the `stable-x86_64-pc-windows-gnu` toolchain.
+
+I also recommend you compile liquid-dsp and use the static `libliquid.a` file to generate the bindings ([see #2 under usage](#usage))

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Unfortunately, this crate does not build liquid-dsp for you, as that's a whole (
 This crate can utilize liquid-dsp in 2 ways:
 1. Build and install liquid-dsp into your system normally by following the official [liquid-dsp installation guide](https://liquidsdr.org/doc/installation/).
 2. Build liquid-dsp, clone this repo, create a directory named `liquid`, and copy your compiled `libliquid.a` and `liquid.h` header files into the directory.
-and that should be it! (For Linux users..)
+
+That should be it! (*For Linux users, anyway..*)
 
 ## For Windows users:
 liquid-dsp doesn't *really* have support for windows, because the MSVC compiler doesn't support all of the C99 features that liquid-dsp requires.
 You can get around this by using MingW64 to build liquid-dsp. Unfortunately, the official installation guide with autotools didn't work for me,
 so I ported liquid-dsp to work with CMake. If you're interested, check out my [pull request](https://github.com/jgaeddert/liquid-dsp/pull/353).
-Also, things don't seem to work right if you're using the (default) `stable-x86_64-pc-windows-msvc` rust toolchain.
-I suggest using the `stable-x86_64-pc-windows-gnu` toolchain.
+Also, things don't seem to work right if you're using the (default) `stable-x86_64-pc-windows-msvc` rust toolchain. Use the `stable-x86_64-pc-windows-gnu` toolchain instead.
 
-I also recommend you compile liquid-dsp and use the static `libliquid.a` file to generate the bindings ([see #2 under usage](#usage))
+If you're using CMake to build liquid-dsp on Windows, you should run cmake with the `-DCMAKE_INSTALL_PREFIX=/ucrt64` argument so that rust can find find the liquid-dsp library and headers.

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main(){
     println!("cargo:rustc-link-search={}", PathBuf::from("liquid").canonicalize().unwrap().to_str().unwrap());
     
     // Link the liquid library
-    println!("cargo:rustc-link-lib=static=liquid");
+    println!("cargo:rustc-link-lib=liquid");
 
     let bindings = bindgen::Builder::default()
         .generate_comments(true)

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,23 @@
 extern crate bindgen;
-
 use std::env;
 use std::path::PathBuf;
 
 fn main(){
-    println!("cargo:rustc-link-lib=liquid");
+    // If on windows, search in the `./liquid` dir for the libliquid.a file
+    // NOTE: On windows, you should be buildling the static library yourself under MingW64 (or similar). Put the `libliquid.a` file in the `./liquid` dir manually.
+    #[cfg(target_os="windows")]
+    println!("cargo:rustc-link-search={}", PathBuf::from("liquid").canonicalize().unwrap().to_str().unwrap());
+    
+    // Link the liquid library
+    println!("cargo:rustc-link-lib=static=liquid");
+
     let bindings = bindgen::Builder::default()
-        .header("wrapper.h")
+        .generate_comments(true)
+        .header("liquid/liquid.h")
         .generate()
-        .expect("Unable to generate bindings!");
+        .expect("Failed to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings.write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+        .expect("Failed to write bindings");
 }

--- a/build.rs
+++ b/build.rs
@@ -3,20 +3,30 @@ use std::env;
 use std::path::PathBuf;
 
 fn main(){
-    // If on windows, search in the `./liquid` dir for the libliquid.a file
-    // NOTE: On windows, you should be buildling the static library yourself under MingW64 (or similar). Put the `libliquid.a` file in the `./liquid` dir manually.
-    #[cfg(target_os="windows")]
-    println!("cargo:rustc-link-search={}", PathBuf::from("liquid").canonicalize().unwrap().to_str().unwrap());
-    
-    // Link the liquid library
-    println!("cargo:rustc-link-lib=liquid");
+    // Use user-provided header and lib files in the `liquid` subdirectory if provided
+    // Otherwise use the system-provided header and lib
+    let header = match std::fs::metadata("liquid/liquid.h") {
+        // `liquid/liquid.h` exists. Use the user-provided static lib
+        Ok(_metadata) => {
+            println!("cargo:rustc-link-search={}", PathBuf::from("liquid").canonicalize().unwrap().to_str().unwrap());
+            println!("cargo:rustc-link-lib=static=liquid");
+            "liquid/liquid.h"
+        },
+        // Use the system-provided header and lib
+        Err(_err) => {
+            println!("cargo:rustc-link-lib=liquid");
+            "wrapper.h"
+        }
+    };
 
+    // Generate the bindings
     let bindings = bindgen::Builder::default()
-        .generate_comments(true)
-        .header("liquid/liquid.h")
-        .generate()
-        .expect("Failed to generate bindings");
+    .generate_comments(true)
+    .header(header)
+    .generate()
+    .expect("Failed to generate bindings");
 
+    // Write the bindings
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings.write_to_file(out_path.join("bindings.rs"))
         .expect("Failed to write bindings");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(improper_ctypes)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,0 +1,1 @@
+#include <liquid/liquid.h>

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,1 +1,0 @@
-#include <liquid/liquid.h>


### PR DESCRIPTION
I wanted to compile liquid-dsp-bindings-sys along with [soapysdr-sys](https://github.com/kevinmehall/rust-soapysdr/tree/master/soapysdr-sys), but, the bindgen versions were not compatible. I forked this repo and made the modification. While I was at it, I updated the rust edition and modified src/lib.rs to suppress some improper ctype warnings.

I have tested the ms_ramp and modem objects and have not observed any errors.